### PR TITLE
Have Words clean up its data directory at startup time.

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       package="com.ids1024.whitakerswords"
-      android:versionCode="7"
-      android:versionName="1.1">
+      android:versionCode="8"
+      android:versionName="1.2">
     <application android:label="@string/app_name" android:icon="@drawable/ic_launcher">
         <activity android:name="WhitakersWords"
                   android:label="@string/app_name">


### PR DESCRIPTION
Files are stored under cache/<version code>/ now, so all files will
be updated when a new version is installed. Any old directories
under cache will be deleted at that time - e.g. version n + 1 will
delete version n's cached directory.

 * Some logging has been added that will display deletion status.
 * There's also some logging that will print if the words subprocess fails.
 * There's also some code to delete any data that is leftover from
   version 1.1 under the files directory.
 * Bumped the version number up to 8/1.2 in preparation for a new
   version on Google Play